### PR TITLE
fix: add dark mode support via CSS variables

### DIFF
--- a/streamlit_tree_select/frontend/public/react-checkbox-tree.css
+++ b/streamlit_tree_select/frontend/public/react-checkbox-tree.css
@@ -300,3 +300,29 @@
   font-size: 14px;
   content: "\f053";
 }
+
+/* Dark mode theme support - use CSS variables from Streamlit parent */
+.react-checkbox-tree {
+  color: var(--text-color);
+  font-family: var(--font);
+}
+
+.rct-title {
+  color: var(--text-color) !important;
+  font-family: var(--font) !important;
+}
+
+.rct-node-icon {
+  color: var(--primary-color) !important;
+}
+
+/* Override hardcoded checkbox colors */
+.rct-icons-fa5 .rct-icon-uncheck::before {
+  color: var(--text-color) !important;
+  opacity: 0.4;
+}
+
+/* Collapse/expand arrows */
+.rct-collapse {
+  color: var(--text-color) !important;
+}


### PR DESCRIPTION
Tree text and checkbox icons now inherit colors from Streamlit's theme CSS variables (--text-color, --font, --primary-color) instead of using hardcoded light-mode colors.